### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/thumbnaild.spec
+++ b/rpm/thumbnaild.spec
@@ -16,7 +16,7 @@ BuildRequires:  pkgconfig(libavformat) >= 11.3
 BuildRequires:  pkgconfig(libavutil)
 BuildRequires:  pkgconfig(libswscale)
 BuildRequires:  pkgconfig(poppler-qt5)
-BuildRequires:  systemd
+BuildRequires:  pkgconfig(systemd)
 
 %description
 Daemon for generating thumbnail images.


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>